### PR TITLE
Support Fastify V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 ![](https://github.com/yonathan06/fastify-now/workflows/CI/badge.svg)
 ![](https://img.shields.io/github/license/yonathan06/fastify-now)
 
-File based routing for [fastify](https://www.fastify.io/)
+File based routing for [fastify](https://www.fastify.io/) (v3)
+
+_If you want to use this library with fastify v2, you should use version 1.X_
 
 ## Example (see example folder)
 
@@ -32,11 +34,15 @@ will result:
 
 ## Install
 
+### Versions
+
+The latest version is 2.X which supports fastify v3
+
 ```sh
 npm install fastify-now
 ```
 
-**For fastify v3:** `npm install fastify-now@next`
+_If you want to use this library with fastify v2, you should use version 1.X_
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Currently supported HTTP methods: `GET, POST, DELETE & PUT`
 In `/routes/user/:id/index.ts`:
 
 ```javascript
-import fastify from 'fastify';
+import { NowRequestHandler } from 'fastify-now';
 
-export const GET: fastify.NowRequestHandler = async (req, rep) => {
+export const GET: NowRequestHandler<{ Params: { id: string } }> = async (req, rep) => {
   return { userId: req.params.id };
 };
 
-export const PUT: fastify.NowRequestHandler = async (req, res) => {
+export const PUT: NowRequestHandler<{ Params: { id: string } }> = async (req, res) => {
   req.log.info(`updating user with id ${req.params.id}`);
   return { message: 'user updated' };
 };
@@ -91,9 +91,12 @@ For that, I created a new interface called `NowRequestHandler`.
 in `/routes/user/index.ts`:
 
 ```javascript
-import fastify from 'fastify';
+import { NowRequestHandler } from 'fastify-now';
 
-export const POST: fastify.NowRequestHandler = async (req, rep) => {
+export const POST: NowRequestHandler<{ Body: { name: string }, Params: { id: string } }> = async (
+  req,
+  rep,
+) => {
   if (req.body.name === 'Jon Doe') {
     /**
      * in async function, you can return undefined if you already sent a response

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Fastify Now - a fastify plugin
 
-![](https://badgen.net/npm/v/fastify-now)
-![](https://github.com/yonathan06/fastify-now/workflows/CI/badge.svg)
-![](https://img.shields.io/github/license/yonathan06/fastify-now)
+![npm badge](https://badgen.net/npm/v/fastify-now)
+![ci badge](https://github.com/yonathan06/fastify-now/workflows/CI/badge.svg)
+![license badge](https://img.shields.io/github/license/yonathan06/fastify-now)
 
 File based routing for [fastify](https://www.fastify.io/) (v3)
 
-_If you want to use this library with fastify v2, you should use version 1.X_
+**If you want to use this library with fastify v2, you should use version 1.X**
 
 ## Example (see example folder)
 
 For the given folder structure
 
-```
+```bash
 ├── src
     ├── routes -- routes folder (can be changed)
     |   ├── user -- user resource endpoint folder
@@ -24,7 +24,7 @@ For the given folder structure
 
 will result:
 
-```
+```bash
 └── / (GET)
     └── user (POST)
         └── /
@@ -42,7 +42,7 @@ The latest version is 2.X which supports fastify v3
 npm install fastify-now
 ```
 
-_If you want to use this library with fastify v2, you should use version 1.X_
+**If you want to use this library with fastify v2, you should use version 1.X**
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 ![ci badge](https://github.com/yonathan06/fastify-now/workflows/CI/badge.svg)
 ![license badge](https://img.shields.io/github/license/yonathan06/fastify-now)
 
-File based routing for [fastify](https://www.fastify.io/) (v3)
-
+File based routing for [fastify](https://www.fastify.io/) (v3).
 **If you want to use this library with fastify v2, you should use version 1.X**
 
 ## Example (see example folder)
@@ -36,13 +35,12 @@ will result:
 
 ### Versions
 
-The latest version is 2.X which supports fastify v3
+The latest version is 2.X which supports fastify v3.
+**If you want to use this library with fastify v2, you should use version 1.X**
 
 ```sh
 npm install fastify-now
 ```
-
-**If you want to use this library with fastify v2, you should use version 1.X**
 
 ## Use
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -37,13 +37,14 @@
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "avvio": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/avvio/-/avvio-6.4.1.tgz",
-      "integrity": "sha512-jeZaUK+F7MuWSNT3VHfltskPJZKqVeTWQqBA4SDaDoLaQ0lb5TOgLeQT1BEuhTIUNISCDCGY3zjYyVmQQ48gKA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.0.3.tgz",
+      "integrity": "sha512-JmGyv7ylCG7TA0Lpb3nHdsVzbmX52co62KT7d/nulcatLD2k9hJbWj6bIfkisEmdpUqmguUHY81Rx/O0iWy3JA==",
       "requires": {
         "archy": "^1.0.0",
         "debug": "^4.0.0",
-        "fastq": "^1.6.0"
+        "fastq": "^1.6.1",
+        "queue-microtask": "^1.1.2"
       }
     },
     "cookie": {
@@ -80,9 +81,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-json-stringify": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-1.20.1.tgz",
-      "integrity": "sha512-PEPWrRZvKqI11fY2uDhLLuoapIda9wVQ2mzAj8rkBfVD7jWvOSIICL0Om1knoReIWKF5y/5bbR/GzcZANaaJfQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.1.0.tgz",
+      "integrity": "sha512-fXHU/VG0QmGzV4IRCKzyuctb5qCXyk8OVARmDpV0u5wZHXwRGU2TFFVT2+UD8+mo24siVAmTygVF2IzfXSzK2w==",
       "requires": {
         "ajv": "^6.11.0",
         "deepmerge": "^4.2.2",
@@ -100,41 +101,131 @@
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastify": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-2.14.0.tgz",
-      "integrity": "sha512-uofJOU9Zf20iklDrACZZVe+qef6dswOe8IUnxUdHTY9QfHv301MgPxodvJFiRE2WAse7YrWr4sI5Lx6YIAuUAA==",
+      "version": "3.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.0.0-rc.4.tgz",
+      "integrity": "sha512-x7W2MzB8Cx+A4UTsXqHL6KxrF4t4N3/sylxXrYeHMY5JIk2vH5HNj0GFUd67wLfLDkakAOm/B7p+f0dMhQ21AA==",
       "requires": {
         "abstract-logging": "^2.0.0",
-        "ajv": "^6.12.0",
-        "avvio": "^6.3.1",
-        "fast-json-stringify": "^1.18.0",
-        "find-my-way": "^2.2.2",
+        "ajv": "^6.12.2",
+        "avvio": "^7.0.3",
+        "fast-json-stringify": "^2.0.0",
+        "find-my-way": "^3.0.0",
         "flatstr": "^1.0.12",
-        "light-my-request": "^3.7.3",
-        "middie": "^4.1.0",
-        "pino": "^5.17.0",
-        "proxy-addr": "^2.0.6",
-        "readable-stream": "^3.6.0",
-        "rfdc": "^1.1.2",
-        "secure-json-parse": "^2.1.0",
-        "tiny-lru": "^7.0.2"
+        "light-my-request": "^4.0.0",
+        "pino": "^6.2.1",
+        "proxy-addr": "^2.0.5",
+        "readable-stream": "^3.4.0",
+        "rfdc": "^1.1.4",
+        "secure-json-parse": "^2.0.0",
+        "tiny-lru": "^7.0.0"
       }
     },
     "fastify-now": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fastify-now/-/fastify-now-1.0.1.tgz",
-      "integrity": "sha512-hNLGb9EDuuHRhd7y00OILlF1BxBZKG0+TNI/mfq+Xj/j70JEb4e5wmYG0vLwGXDQUUpFF22/MvBTPp7IfZdFiQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-now/-/fastify-now-2.0.0.tgz",
+      "integrity": "sha512-sM4DdDLsa9F72YS3t0XmFVUf8jPXQpSq5HKIAz+XDiWeWrPMGkRz+r9DJbLDc9CqJbfv4LnAHb5HBVEJXxm6xA==",
       "requires": {
-        "fastify": "^2.13.0",
-        "fastify-plugin": "^1.6.1"
+        "fastify": "^3.0.0-rc.4",
+        "fastify-plugin": "^2.0.0"
+      },
+      "dependencies": {
+        "avvio": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/avvio/-/avvio-7.0.3.tgz",
+          "integrity": "sha512-JmGyv7ylCG7TA0Lpb3nHdsVzbmX52co62KT7d/nulcatLD2k9hJbWj6bIfkisEmdpUqmguUHY81Rx/O0iWy3JA==",
+          "requires": {
+            "archy": "^1.0.0",
+            "debug": "^4.0.0",
+            "fastq": "^1.6.1",
+            "queue-microtask": "^1.1.2"
+          }
+        },
+        "fast-json-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.1.0.tgz",
+          "integrity": "sha512-fXHU/VG0QmGzV4IRCKzyuctb5qCXyk8OVARmDpV0u5wZHXwRGU2TFFVT2+UD8+mo24siVAmTygVF2IzfXSzK2w==",
+          "requires": {
+            "ajv": "^6.11.0",
+            "deepmerge": "^4.2.2",
+            "string-similarity": "^4.0.1"
+          }
+        },
+        "fastify": {
+          "version": "3.0.0-rc.4",
+          "resolved": "https://registry.npmjs.org/fastify/-/fastify-3.0.0-rc.4.tgz",
+          "integrity": "sha512-x7W2MzB8Cx+A4UTsXqHL6KxrF4t4N3/sylxXrYeHMY5JIk2vH5HNj0GFUd67wLfLDkakAOm/B7p+f0dMhQ21AA==",
+          "requires": {
+            "abstract-logging": "^2.0.0",
+            "ajv": "^6.12.2",
+            "avvio": "^7.0.3",
+            "fast-json-stringify": "^2.0.0",
+            "find-my-way": "^3.0.0",
+            "flatstr": "^1.0.12",
+            "light-my-request": "^4.0.0",
+            "pino": "^6.2.1",
+            "proxy-addr": "^2.0.5",
+            "readable-stream": "^3.4.0",
+            "rfdc": "^1.1.4",
+            "secure-json-parse": "^2.0.0",
+            "tiny-lru": "^7.0.0"
+          }
+        },
+        "find-my-way": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-3.0.1.tgz",
+          "integrity": "sha512-tHUHIRGTcfl3phGKLZeD2Xkb+I0QZr4xduSwCJG5Ke11pdJTGuMDtAyAiJzUdWBZJgHA0H42Pb0WF3H321KbRA==",
+          "requires": {
+            "fast-decode-uri-component": "^1.0.0",
+            "safe-regex2": "^2.0.0",
+            "semver-store": "^0.3.0"
+          }
+        },
+        "light-my-request": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.0.1.tgz",
+          "integrity": "sha512-kGRfzvSS9P/zEsnu34pUisOz2FAPqkHFJfdezW6HRzLLlzjY+1LTRRuh2d82SkW/M/QWNVWnXTZ0HMUydz2fgg==",
+          "requires": {
+            "ajv": "^6.12.2",
+            "cookie": "^0.4.0",
+            "readable-stream": "^3.6.0",
+            "set-cookie-parser": "^2.4.1"
+          }
+        },
+        "pino": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-6.3.2.tgz",
+          "integrity": "sha512-EiP3L1hoFw19KPocWimjnfXeysld0ne89ZRQ+bf8nAeA2TyuLoggNlibAi+Kla67GvQBopLdIZOsh1z/Lruo5Q==",
+          "requires": {
+            "fast-redact": "^2.0.0",
+            "fast-safe-stringify": "^2.0.7",
+            "flatstr": "^1.0.12",
+            "pino-std-serializers": "^2.4.2",
+            "quick-format-unescaped": "^4.0.1",
+            "sonic-boom": "^1.0.0"
+          }
+        },
+        "quick-format-unescaped": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+          "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
+        },
+        "sonic-boom": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.0.1.tgz",
+          "integrity": "sha512-o9tx+bonVEXSaPtptyXQXpP8l6UV9Bi3im2geZskvWw2a/o/hrbWI7EBbbv+rOx6Hubnzun9GgH4WfbgEA3MFQ==",
+          "requires": {
+            "atomic-sleep": "^1.0.0",
+            "flatstr": "^1.0.12"
+          }
+        }
       }
     },
     "fastify-plugin": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-1.6.1.tgz",
-      "integrity": "sha512-APBcb27s+MjaBIerFirYmBLatoPCgmHZM6XP0K+nDL9k0yX8NJPWDY1RAC3bh6z+AB5ULS2j31BUfLMT3uaZ4A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-2.0.0.tgz",
+      "integrity": "sha512-5c7xwArjeY5T7PFw+TM66gz7E6mQpEK4PXKXVOmxLXUYh49D34pLAL+gbSRLgr7gg8fTOaNjB9fSj0adV5rrXg==",
       "requires": {
-        "semver": "^6.3.0"
+        "semver": "^7.3.2"
       }
     },
     "fastq": {
@@ -146,9 +237,9 @@
       }
     },
     "find-my-way": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-2.2.2.tgz",
-      "integrity": "sha512-zk3eOsS1tABNQjII0vCbhkqgsX/COpRUxl0b5rlA41V2Ft7jWDr30LhYq4BZXLAlzw5yskg24XQG/U1wCT30vQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-3.0.1.tgz",
+      "integrity": "sha512-tHUHIRGTcfl3phGKLZeD2Xkb+I0QZr4xduSwCJG5Ke11pdJTGuMDtAyAiJzUdWBZJgHA0H42Pb0WF3H321KbRA==",
       "requires": {
         "fast-decode-uri-component": "^1.0.0",
         "safe-regex2": "^2.0.0",
@@ -181,23 +272,14 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "light-my-request": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-3.7.4.tgz",
-      "integrity": "sha512-xiAMJBW3Zaxz+C42Uo0N6spUqhcSsmB9IqxE/VF+J7HWuxsRPeOzeY2SOMtTR0dbsX/RVpxGAFHR0uB6vuTs8A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-4.0.1.tgz",
+      "integrity": "sha512-kGRfzvSS9P/zEsnu34pUisOz2FAPqkHFJfdezW6HRzLLlzjY+1LTRRuh2d82SkW/M/QWNVWnXTZ0HMUydz2fgg==",
       "requires": {
-        "ajv": "^6.10.2",
+        "ajv": "^6.12.2",
         "cookie": "^0.4.0",
-        "readable-stream": "^3.4.0",
+        "readable-stream": "^3.6.0",
         "set-cookie-parser": "^2.4.1"
-      }
-    },
-    "middie": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/middie/-/middie-4.1.0.tgz",
-      "integrity": "sha512-eylPpZA+K3xO9kpDjagoPkEUkNcWV3EAo5OEz0MqsekUpT7KbnQkk8HNZkh4phx2vvOAmNNZuLRWF9lDDHPpVQ==",
-      "requires": {
-        "path-to-regexp": "^4.0.0",
-        "reusify": "^1.0.2"
       }
     },
     "ms": {
@@ -205,22 +287,17 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "path-to-regexp": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.5.tgz",
-      "integrity": "sha512-l+fTaGG2N9ZRpCEUj5fG1VKdDLaiqwCIvPngpnxzREhcdobhZC4ou4w984HBu72DqAJ5CfcdV6tjqNOunfpdsQ=="
-    },
     "pino": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
-      "integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.3.2.tgz",
+      "integrity": "sha512-EiP3L1hoFw19KPocWimjnfXeysld0ne89ZRQ+bf8nAeA2TyuLoggNlibAi+Kla67GvQBopLdIZOsh1z/Lruo5Q==",
       "requires": {
         "fast-redact": "^2.0.0",
         "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.12",
         "pino-std-serializers": "^2.4.2",
-        "quick-format-unescaped": "^3.0.3",
-        "sonic-boom": "^0.7.5"
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.0"
       }
     },
     "pino-std-serializers": {
@@ -242,10 +319,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "queue-microtask": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.3.tgz",
+      "integrity": "sha512-zC1ZDLKFhZSa8vAdFbkOGouHcOUMgUAI/2/3on/KktpY+BaVqABkzDSsCSvJfmLbICOnrEuF9VIMezZf+T0mBA=="
+    },
     "quick-format-unescaped": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
-      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -291,9 +373,9 @@
       "integrity": "sha512-GckO+MS/wT4UogDyoI/H/S1L0MCcKS1XX/vp48wfmU7Nw4woBmb8mIpu4zPBQjKlRT88/bt9xdoV4111jPpNJA=="
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "semver-store": {
       "version": "0.3.0",
@@ -306,9 +388,9 @@
       "integrity": "sha512-LkSDwseogN5l6TerqGzFzL9mUDTxSq3hX2b5AaynjC1nSCNWiDypEgHatfc0v6KcnfgV3/6F6h4ABh6igjzlQQ=="
     },
     "sonic-boom": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
-      "integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.0.1.tgz",
+      "integrity": "sha512-o9tx+bonVEXSaPtptyXQXpP8l6UV9Bi3im2geZskvWw2a/o/hrbWI7EBbbv+rOx6Hubnzun9GgH4WfbgEA3MFQ==",
       "requires": {
         "atomic-sleep": "^1.0.0",
         "flatstr": "^1.0.12"

--- a/example/package.json
+++ b/example/package.json
@@ -9,8 +9,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "fastify": "^2.14.0",
-    "fastify-now": "^1.0.1"
+    "fastify": "^3.0.0-rc.4",
+    "fastify-now": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^13.13.4",

--- a/example/src/routes/index.ts
+++ b/example/src/routes/index.ts
@@ -1,5 +1,5 @@
-import fastify from 'fastify';
+import { NowRequestHandler } from 'fastify-now';
 
-export const GET: fastify.NowRequestHandler = async (req, rep) => {
+export const GET: NowRequestHandler = async (req, rep) => {
   return { message: 'hello world' };
 };

--- a/example/src/routes/user/:id.ts
+++ b/example/src/routes/user/:id.ts
@@ -1,10 +1,10 @@
-import fastify from 'fastify';
+import { NowRequestHandler } from 'fastify-now';
 
-export const GET: fastify.NowRequestHandler = async (req, rep) => {
+export const GET: NowRequestHandler<{ Params: { id: string } }> = async (req, rep) => {
   return { userId: req.params.id };
 };
 
-export const PUT: fastify.NowRequestHandler = async (req, res) => {
+export const PUT: NowRequestHandler<{ Params: { id: string } }> = async (req, res) => {
   req.log.info(`updating user with id ${req.params.id}`);
   return { message: 'user updated' };
 };

--- a/example/src/routes/user/index.ts
+++ b/example/src/routes/user/index.ts
@@ -1,6 +1,9 @@
-import fastify from 'fastify';
+import { NowRequestHandler } from 'fastify-now';
 
-export const POST: fastify.NowRequestHandler = async (req, rep) => {
+export const POST: NowRequestHandler<{ Body: { name: string }; Params: { id: string } }> = async (
+  req,
+  rep,
+) => {
   if (req.body.name === 'Jon Doe') {
     /**
      * in async function, you can return undefined if you already sent a response

--- a/index.ts
+++ b/index.ts
@@ -39,10 +39,9 @@ function addRequestHandler(
   fileRouteServerPath: string,
 ) {
   const handler = module[method.toUpperCase()] as NowRequestHandler;
-  console.log('handler', handler);
   if (handler) {
     server.log.debug(`${method.toUpperCase()} ${fileRouteServerPath}`);
-    server[method](fileRouteServerPath, handler.arguments[0] || {}, handler);
+    server[method](fileRouteServerPath, handler.opts || {}, handler);
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -78,7 +78,7 @@ interface FastifyNowOpts {
 const fastifyNow: FastifyPlugin<FastifyNowOpts> = (
   server: DefaultFastifyInstance,
   opts: FastifyNowOpts,
-  next: (error?: Error) => void,
+  next: (error?: any) => void,
 ) => {
   if (!(opts && opts.routesFolder)) {
     next(new Error('fastify-now: must provide opts.routesFolder'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-now",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Fastify Now - file based routing for fastify",
   "author": "Yonatan Bendahan",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "node": "12.x.x"
   },
   "dependencies": {
-    "fastify": "^2.13.0",
-    "fastify-plugin": "^1.6.1"
+    "fastify": "^3.0.0-rc.4",
+    "fastify-plugin": "^2.0.0"
   },
   "devDependencies": {
     "@ava/typescript": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-now",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Fastify Now - file based routing for fastify",
   "author": "Yonatan Bendahan",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node": "12.x.x"
   },
   "dependencies": {
-    "fastify": "^3.0.0-rc.4",
+    "fastify": "^3.0.0",
     "fastify-plugin": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-now",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Fastify Now - file based routing for fastify",
   "author": "Yonatan Bendahan",
   "keywords": [

--- a/test/regular-server/index.spec.ts
+++ b/test/regular-server/index.spec.ts
@@ -113,8 +113,8 @@ test('/book GET should work with query string', async (t) => {
     path: `/book?name=${bookName}`,
     method: 'GET',
   });
-  t.is(res.body, `{"name": ${bookName}}`);
-  t.is(res.statusCode, 400);
+  t.is(res.body, `{"name":"${bookName}"}`);
+  t.is(res.statusCode, 200);
 });
 
 test('/group/:id GET should exist', async (t) => {

--- a/test/regular-server/index.spec.ts
+++ b/test/regular-server/index.spec.ts
@@ -1,23 +1,23 @@
 import test from 'ava';
 import { initServer } from './test-server';
-import fastify from 'fastify';
+import { FastifyInstance } from 'fastify';
 
 test.before(async (t) => {
   t.context['server'] = await initServer(5000);
 });
 
 test.after.always(async (t) => {
-  (t.context['server'] as fastify.FastifyInstance).close();
+  (t.context['server'] as FastifyInstance).close();
 });
 
 test('Server should not be null', (t) => {
-  const server = t.context['server'] as fastify.FastifyInstance;
+  const server = t.context['server'] as FastifyInstance;
   server.printRoutes();
   t.truthy(server);
 });
 
 test('/ GET should exist', async (t) => {
-  const server = t.context['server'] as fastify.FastifyInstance;
+  const server = t.context['server'] as FastifyInstance;
   const res = await server.inject({
     path: '/',
     method: 'GET',
@@ -28,7 +28,7 @@ test('/ GET should exist', async (t) => {
 
 test('/user POST should exist', async (t) => {
   const name = 'my name';
-  const server = t.context['server'] as fastify.FastifyInstance;
+  const server = t.context['server'] as FastifyInstance;
   const res = await server.inject({
     path: '/user',
     method: 'POST',
@@ -41,7 +41,7 @@ test('/user POST should exist', async (t) => {
 });
 
 test('/user POST fail over schema validation', async (t) => {
-  const server = t.context['server'] as fastify.FastifyInstance;
+  const server = t.context['server'] as FastifyInstance;
   const res = await server.inject({
     path: '/user',
     method: 'POST',
@@ -50,7 +50,7 @@ test('/user POST fail over schema validation', async (t) => {
 });
 
 test('/user POST fail over bad payload', async (t) => {
-  const server = t.context['server'] as fastify.FastifyInstance;
+  const server = t.context['server'] as FastifyInstance;
   const res = await server.inject({
     path: '/user',
     method: 'POST',
@@ -62,7 +62,7 @@ test('/user POST fail over bad payload', async (t) => {
 });
 
 test('/user/:id PUT should exist', async (t) => {
-  const server = t.context['server'] as fastify.FastifyInstance;
+  const server = t.context['server'] as FastifyInstance;
   const res = await server.inject({
     path: '/user/some-id',
     method: 'PUT',
@@ -73,7 +73,7 @@ test('/user/:id PUT should exist', async (t) => {
 
 test('/user/:id GET should exist', async (t) => {
   const userId = 'some-id';
-  const server = t.context['server'] as fastify.FastifyInstance;
+  const server = t.context['server'] as FastifyInstance;
   const res = await server.inject({
     path: `/user/${userId}`,
     method: 'GET',
@@ -83,7 +83,7 @@ test('/user/:id GET should exist', async (t) => {
 });
 
 test('/books GET should fail over no query string schema validation', async (t) => {
-  const server = t.context['server'] as fastify.FastifyInstance;
+  const server = t.context['server'] as FastifyInstance;
   const res = await server.inject({
     path: `/book`,
     method: 'GET',
@@ -96,7 +96,7 @@ test('/books GET should fail over no query string schema validation', async (t) 
 });
 
 test('/group/:id GET should exist', async (t) => {
-  const server = t.context['server'] as fastify.FastifyInstance;
+  const server = t.context['server'] as FastifyInstance;
   const res = await server.inject({
     path: `/group/123`,
     method: 'GET',
@@ -106,7 +106,7 @@ test('/group/:id GET should exist', async (t) => {
 });
 
 test('/group/:id/path/topic/:topicId GET should exist', async (t) => {
-  const server = t.context['server'] as fastify.FastifyInstance;
+  const server = t.context['server'] as FastifyInstance;
   const res = await server.inject({
     path: `/group/123/path/topic/456`,
     method: 'GET',

--- a/test/regular-server/index.spec.ts
+++ b/test/regular-server/index.spec.ts
@@ -1,38 +1,34 @@
-import test from 'ava';
+import anyTest, { TestInterface } from 'ava';
+
 import { initServer } from './test-server';
-import {
-  FastifyInstance,
-  RawServerBase,
-  RawRequestDefaultExpression,
-  RawReplyDefaultExpression,
-} from 'fastify';
+import { FastifyInstance, FastifyLoggerInstance } from 'fastify';
+import { Server, IncomingMessage, ServerResponse } from 'http';
 
 type DefaultFastifyInstance = FastifyInstance<
-  RawServerBase,
-  RawRequestDefaultExpression<RawServerBase>,
-  RawReplyDefaultExpression<RawServerBase>
+  Server,
+  IncomingMessage,
+  ServerResponse,
+  FastifyLoggerInstance
 >;
 
-interface TestContext {
-  server: DefaultFastifyInstance;
-}
+const test = anyTest as TestInterface<{ server: DefaultFastifyInstance }>;
 
 test.before(async (t) => {
-  t.context['server'] = await initServer(5000);
+  t.context.server = await initServer(5000);
 });
 
 test.after.always(async (t) => {
-  (t.context['server'] as FastifyInstance).close();
+  t.context.server.close();
 });
 
 test('Server should not be null', (t) => {
-  const server = t.context['server'] as FastifyInstance;
+  const { server } = t.context;
   server.printRoutes();
   t.truthy(server);
 });
 
 test('/ GET should exist', async (t) => {
-  const server = t.context['server'] as FastifyInstance;
+  const { server } = t.context;
   const res = await server.inject({
     path: '/',
     method: 'GET',
@@ -43,7 +39,7 @@ test('/ GET should exist', async (t) => {
 
 test('/user POST should exist', async (t) => {
   const name = 'my name';
-  const server = t.context['server'] as FastifyInstance;
+  const { server } = t.context;
   const res = await server.inject({
     path: '/user',
     method: 'POST',
@@ -56,7 +52,7 @@ test('/user POST should exist', async (t) => {
 });
 
 test('/user POST fail over schema validation', async (t) => {
-  const server = t.context['server'] as FastifyInstance;
+  const { server } = t.context;
   const res = await server.inject({
     path: '/user',
     method: 'POST',
@@ -65,7 +61,7 @@ test('/user POST fail over schema validation', async (t) => {
 });
 
 test('/user POST fail over bad payload', async (t) => {
-  const server = t.context['server'] as FastifyInstance;
+  const { server } = t.context;
   const res = await server.inject({
     path: '/user',
     method: 'POST',
@@ -77,7 +73,7 @@ test('/user POST fail over bad payload', async (t) => {
 });
 
 test('/user/:id PUT should exist', async (t) => {
-  const server = t.context['server'] as FastifyInstance;
+  const { server } = t.context;
   const res = await server.inject({
     path: '/user/some-id',
     method: 'PUT',
@@ -88,7 +84,7 @@ test('/user/:id PUT should exist', async (t) => {
 
 test('/user/:id GET should exist', async (t) => {
   const userId = 'some-id';
-  const server = t.context['server'] as FastifyInstance;
+  const { server } = t.context;
   const res = await server.inject({
     path: `/user/${userId}`,
     method: 'GET',
@@ -98,7 +94,7 @@ test('/user/:id GET should exist', async (t) => {
 });
 
 test('/book GET should fail over no query string schema validation', async (t) => {
-  const server = t.context['server'] as FastifyInstance;
+  const { server } = t.context;
   const res = await server.inject({
     path: `/book`,
     method: 'GET',
@@ -111,7 +107,7 @@ test('/book GET should fail over no query string schema validation', async (t) =
 });
 
 test('/book GET should work with query string', async (t) => {
-  const server = t.context['server'] as FastifyInstance;
+  const { server } = t.context;
   const bookName = 'myBook';
   const res = await server.inject({
     path: `/book?name=${bookName}`,
@@ -122,7 +118,7 @@ test('/book GET should work with query string', async (t) => {
 });
 
 test('/group/:id GET should exist', async (t) => {
-  const server = t.context['server'] as FastifyInstance;
+  const { server } = t.context;
   const res = await server.inject({
     path: `/group/123`,
     method: 'GET',
@@ -132,7 +128,7 @@ test('/group/:id GET should exist', async (t) => {
 });
 
 test('/group/:id/path/topic/:topicId GET should exist', async (t) => {
-  const server = t.context['server'] as FastifyInstance;
+  const { server } = t.context;
   const res = await server.inject({
     path: `/group/123/path/topic/456`,
     method: 'GET',

--- a/test/regular-server/index.spec.ts
+++ b/test/regular-server/index.spec.ts
@@ -1,6 +1,21 @@
 import test from 'ava';
 import { initServer } from './test-server';
-import { FastifyInstance } from 'fastify';
+import {
+  FastifyInstance,
+  RawServerBase,
+  RawRequestDefaultExpression,
+  RawReplyDefaultExpression,
+} from 'fastify';
+
+type DefaultFastifyInstance = FastifyInstance<
+  RawServerBase,
+  RawRequestDefaultExpression<RawServerBase>,
+  RawReplyDefaultExpression<RawServerBase>
+>;
+
+interface TestContext {
+  server: DefaultFastifyInstance;
+}
 
 test.before(async (t) => {
   t.context['server'] = await initServer(5000);
@@ -82,7 +97,7 @@ test('/user/:id GET should exist', async (t) => {
   t.is(json.userId, userId);
 });
 
-test('/books GET should fail over no query string schema validation', async (t) => {
+test('/book GET should fail over no query string schema validation', async (t) => {
   const server = t.context['server'] as FastifyInstance;
   const res = await server.inject({
     path: `/book`,
@@ -92,6 +107,17 @@ test('/books GET should fail over no query string schema validation', async (t) 
     res.body,
     `{"statusCode":400,"error":"Bad Request","message":"querystring should have required property 'name'"}`,
   );
+  t.is(res.statusCode, 400);
+});
+
+test('/book GET should work with query string', async (t) => {
+  const server = t.context['server'] as FastifyInstance;
+  const bookName = 'myBook';
+  const res = await server.inject({
+    path: `/book?name=${bookName}`,
+    method: 'GET',
+  });
+  t.is(res.body, `{"name": ${bookName}}`);
   t.is(res.statusCode, 400);
 });
 

--- a/test/regular-server/test-server/routes/book.ts
+++ b/test/regular-server/test-server/routes/book.ts
@@ -1,6 +1,6 @@
-import fastify from 'fastify';
+import { NowRequestHandler } from '../../../../index';
 
-export const GET: fastify.NowRequestHandler = async (req, rep) => {
+export const GET: NowRequestHandler = async (req, rep) => {
   return { message: 'hello world' };
 };
 

--- a/test/regular-server/test-server/routes/book.ts
+++ b/test/regular-server/test-server/routes/book.ts
@@ -1,7 +1,7 @@
 import { NowRequestHandler } from '../../../../index';
 
-export const GET: NowRequestHandler = async (req, rep) => {
-  return { message: 'hello world' };
+export const GET: NowRequestHandler<{ Querystring: { name: string } }> = async (req, rep) => {
+  return { name: req.query.name };
 };
 
 GET.opts = {

--- a/test/regular-server/test-server/routes/group/:id/index.ts
+++ b/test/regular-server/test-server/routes/group/:id/index.ts
@@ -1,5 +1,5 @@
-import fastify from 'fastify';
+import { NowRequestHandler } from '../../../../../../index';
 
-export const GET: fastify.NowRequestHandler = async (req, rep) => {
+export const GET: NowRequestHandler = async (req, rep) => {
   return { id: req.params.id };
 };

--- a/test/regular-server/test-server/routes/group/:id/index.ts
+++ b/test/regular-server/test-server/routes/group/:id/index.ts
@@ -1,5 +1,5 @@
 import { NowRequestHandler } from '../../../../../../index';
 
-export const GET: NowRequestHandler = async (req, rep) => {
+export const GET: NowRequestHandler<{ Params: { id: string } }> = async (req, rep) => {
   return { id: req.params.id };
 };

--- a/test/regular-server/test-server/routes/group/:id/path/topic/:topicId.ts
+++ b/test/regular-server/test-server/routes/group/:id/path/topic/:topicId.ts
@@ -1,5 +1,5 @@
-import fastify from 'fastify';
+import { NowRequestHandler } from '../../../../../../../../index';
 
-export const GET: fastify.NowRequestHandler = async (req, rep) => {
+export const GET: NowRequestHandler = async (req, rep) => {
   return { groupId: req.params.id, topicId: req.params.topicId };
 };

--- a/test/regular-server/test-server/routes/group/:id/path/topic/:topicId.ts
+++ b/test/regular-server/test-server/routes/group/:id/path/topic/:topicId.ts
@@ -1,5 +1,8 @@
 import { NowRequestHandler } from '../../../../../../../../index';
 
-export const GET: NowRequestHandler = async (req, rep) => {
+export const GET: NowRequestHandler<{ Params: { id: string; topicId: string } }> = async (
+  req,
+  rep,
+) => {
   return { groupId: req.params.id, topicId: req.params.topicId };
 };

--- a/test/regular-server/test-server/routes/index.ts
+++ b/test/regular-server/test-server/routes/index.ts
@@ -1,5 +1,5 @@
-import fastify from 'fastify';
+import { NowRequestHandler } from '../../../../index';
 
-export const GET: fastify.NowRequestHandler = async (req, rep) => {
+export const GET: NowRequestHandler = async (req, rep) => {
   return { message: 'hello world' };
 };

--- a/test/regular-server/test-server/routes/user/:id.ts
+++ b/test/regular-server/test-server/routes/user/:id.ts
@@ -1,10 +1,10 @@
-import fastify from 'fastify';
+import { NowRequestHandler } from '../../../../../index';
 
-export const GET: fastify.NowRequestHandler = async (req, rep) => {
+export const GET: NowRequestHandler = async (req, rep) => {
   return { userId: req.params.id };
 };
 
-export const PUT: fastify.NowRequestHandler = async (req, res) => {
+export const PUT: NowRequestHandler = async (req, res) => {
   req.log.info(`updating user with id ${req.params.id}`);
   return { message: 'user updated' };
 };

--- a/test/regular-server/test-server/routes/user/:id.ts
+++ b/test/regular-server/test-server/routes/user/:id.ts
@@ -1,10 +1,10 @@
 import { NowRequestHandler } from '../../../../../index';
 
-export const GET: NowRequestHandler = async (req, rep) => {
+export const GET: NowRequestHandler<{ Params: { id: string } }> = async (req, rep) => {
   return { userId: req.params.id };
 };
 
-export const PUT: NowRequestHandler = async (req, res) => {
+export const PUT: NowRequestHandler<{ Params: { id: string } }> = async (req, res) => {
   req.log.info(`updating user with id ${req.params.id}`);
   return { message: 'user updated' };
 };

--- a/test/regular-server/test-server/routes/user/index.ts
+++ b/test/regular-server/test-server/routes/user/index.ts
@@ -1,6 +1,6 @@
 import { NowRequestHandler } from '../../../../../index';
 
-export const POST: NowRequestHandler = async (req, rep) => {
+export const POST: NowRequestHandler<{ Body: { name: string } }> = async (req, rep) => {
   if (req.body.name === 'Jon Doe') {
     /**
      * in async function, you can return undefined if you already sent a response

--- a/test/regular-server/test-server/routes/user/index.ts
+++ b/test/regular-server/test-server/routes/user/index.ts
@@ -1,6 +1,6 @@
-import fastify from 'fastify';
+import { NowRequestHandler } from '../../../../../index';
 
-export const POST: fastify.NowRequestHandler = async (req, rep) => {
+export const POST: NowRequestHandler = async (req, rep) => {
   if (req.body.name === 'Jon Doe') {
     /**
      * in async function, you can return undefined if you already sent a response

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": ".build",
-    "declaration": true
+    "declaration": true,
+    "strict": true
   },
   "include": ["index.ts"],
   "exclude": ["**/*.spec.ts", "node_modules"]

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,7 +9,8 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "test-build",
-    "baseUrl": "test"
+    "baseUrl": "test",
+    "strict": true
   },
   "exclude": ["node_modules", "example"]
 }


### PR DESCRIPTION
# `NowRequestHandler`

No longer part of `fastify` module type, need to be imported directly from `fastify-now`
```javascript
import { NowRequestHandler } from 'fastify-now';
```
also, must include request types in typescript:
```javascript
export const POST: NowRequestHandler<{ Body: { name: string }; Params: { id: string } }> = async (
  req,
  rep,
) => {
  if (req.body.name === 'Jon Doe') {
    /**
     * in async function, you can return undefined if you already sent a response
     * then it won't try to send a response again with the returned value;
     */
    rep.status(400).send({ message: 'Name can not be Jon Doe' });
    return;
  }
  return { userId: req.params.id };
};
```