### PR TITLE
Support node above version 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   },
   "engines": {
-    "node": "12.x.x"
+    "node": ">=12.x.x"
   },
   "dependencies": {
     "fastify": "^3.0.0",


### PR DESCRIPTION
All tests pass with node 15.6. 

This is a necessary change for projects using later node features (such as optional chaining). 