### PR TITLE
accept .ts route files if supported

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,3 +15,5 @@ jobs:
       run: npm install
     - name: Test
       run: npm test
+    - name: Test TypeScript
+      run: npm run test:ts

--- a/index.ts
+++ b/index.ts
@@ -31,13 +31,13 @@ const typeScriptEnabled = Boolean(
   process[Symbol.for('ts-node.register.instance')] || process.env.TS_NODE_DEV,
 );
 
-const extensions = [".js"];
+const extensions = ['.js'];
 if (typeScriptEnabled) {
-  extensions.push(".ts");
+  extensions.push('.ts');
 }
 
 const isRoute = (ext: string) => extensions.includes(ext);
-const isTest = (name: string) => name.endsWith(".test") || name.endsWith(".spec");
+const isTest = (name: string) => name.endsWith('.test') || name.endsWith('.spec');
 const isDeclaration = (name: string, ext: string) => ext === '.ts' && name.endsWith('.d');
 
 function addRequestHandler(

--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,18 @@ enum HTTPMethod {
   TRACE = 'trace',
 }
 
+const typeScriptEnabled = Boolean(
+  process[Symbol.for('ts-node.register.instance')] || process.env.TS_NODE_DEV,
+);
+
+const extensions = [".js"];
+if (typeScriptEnabled) {
+  extensions.push(".ts");
+}
+
+const isRoute = (ext: string) => extensions.includes(ext);
+const isTest = (name: string) => name.endsWith(".test") || name.endsWith(".spec");
+
 function addRequestHandler(
   module: { [key in HTTPMethod]: NowRequestHandler },
   method: HTTPMethod,
@@ -47,12 +59,13 @@ export function registerRoutes(server: FastifyInstance, folder: string, pathPref
     if (folderOrFile.isDirectory()) {
       registerRoutes(server, currentPath, routeServerPath);
     } else if (folderOrFile.isFile()) {
-      if (!folderOrFile.name.endsWith('.js') || /\.(test)|(spec)\.js$/i.test(folderOrFile.name)) {
+      const { ext, name } = path.parse(folderOrFile.name);
+      if (!isRoute(ext) || isTest(name)) {
         return;
       }
       let fileRouteServerPath = pathPrefix;
-      if (folderOrFile.name !== 'index.js') {
-        fileRouteServerPath += '/' + folderOrFile.name.replace('[', ':').replace(/\]?.js/, '');
+      if (name !== 'index') {
+        fileRouteServerPath += '/' + name.replace('[', ':').replace(/\]?$/, '');
       }
       if (fileRouteServerPath.length === 0) {
         fileRouteServerPath = '/';

--- a/index.ts
+++ b/index.ts
@@ -38,6 +38,7 @@ if (typeScriptEnabled) {
 
 const isRoute = (ext: string) => extensions.includes(ext);
 const isTest = (name: string) => name.endsWith(".test") || name.endsWith(".spec");
+const isDeclaration = (name: string, ext: string) => ext === '.ts' && name.endsWith('.d');
 
 function addRequestHandler(
   module: { [key in HTTPMethod]: NowRequestHandler },
@@ -60,7 +61,7 @@ export function registerRoutes(server: FastifyInstance, folder: string, pathPref
       registerRoutes(server, currentPath, routeServerPath);
     } else if (folderOrFile.isFile()) {
       const { ext, name } = path.parse(folderOrFile.name);
-      if (!isRoute(ext) || isTest(name)) {
+      if (!isRoute(ext) || isTest(name) || isDeclaration(name, ext)) {
         return;
       }
       let fileRouteServerPath = pathPrefix;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,16 @@
     "build": "tsc",
     "prepublish": "npm test && npm run build",
     "pretest": "tsc --project tsconfig.test.json",
-    "test": "ava test-build/**/*.spec.js"
+    "test": "ava test-build/**/*.spec.js",
+    "test:ts": "ava test/**/*.spec.ts"
+  },
+  "ava": {
+    "extensions": [
+      "js", "ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ]
   },
   "husky": {
     "hooks": {
@@ -36,14 +45,15 @@
   "devDependencies": {
     "@ava/typescript": "^1.1.1",
     "@types/node": "^12.7.8",
-    "ava": "^3.8.1",
     "@typescript-eslint/eslint-plugin": "^2.31.0",
     "@typescript-eslint/parser": "^2.31.0",
+    "ava": "^3.8.1",
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",
     "husky": "^4.2.5",
     "prettier": "^2.0.5",
+    "ts-node": "^10.2.0",
     "typescript": "^3.8.3"
   }
 }

--- a/test/regular-server-ts-and-js/index.spec.ts
+++ b/test/regular-server-ts-and-js/index.spec.ts
@@ -1,0 +1,138 @@
+import anyTest, { TestInterface } from 'ava';
+
+import { initServer } from './test-server';
+import { FastifyInstance, FastifyLoggerInstance } from 'fastify';
+import { Server, IncomingMessage, ServerResponse } from 'http';
+
+type DefaultFastifyInstance = FastifyInstance<
+  Server,
+  IncomingMessage,
+  ServerResponse,
+  FastifyLoggerInstance
+>;
+
+const test = anyTest as TestInterface<{ server: DefaultFastifyInstance }>;
+
+test.before(async (t) => {
+  t.context.server = await initServer(5003);
+});
+
+test.after.always(async (t) => {
+  t.context.server.close();
+});
+
+test('Server should not be null', (t) => {
+  const { server } = t.context;
+  server.printRoutes();
+  t.truthy(server);
+});
+
+test('/ GET should exist', async (t) => {
+  const { server } = t.context;
+  const res = await server.inject({
+    path: '/',
+    method: 'GET',
+  });
+  const json = JSON.parse(res.body);
+  t.is(json.message, 'hello world');
+});
+
+test('/user POST should exist', async (t) => {
+  const name = 'my name';
+  const { server } = t.context;
+  const res = await server.inject({
+    path: '/user',
+    method: 'POST',
+    payload: {
+      name,
+    },
+  });
+  const json = JSON.parse(res.body);
+  t.is(json.name, name);
+});
+
+test('/user POST fail over schema validation', async (t) => {
+  const { server } = t.context;
+  const res = await server.inject({
+    path: '/user',
+    method: 'POST',
+  });
+  t.is(res.statusCode, 400);
+});
+
+test('/user POST fail over bad payload', async (t) => {
+  const { server } = t.context;
+  const res = await server.inject({
+    path: '/user',
+    method: 'POST',
+    payload: {
+      name: 'Jon Doe',
+    },
+  });
+  t.is(res.statusCode, 400);
+});
+
+test('/user/:id PUT should exist', async (t) => {
+  const { server } = t.context;
+  const res = await server.inject({
+    path: '/user/some-id',
+    method: 'PUT',
+  });
+  const json = JSON.parse(res.body);
+  t.is(json.message, 'user updated');
+});
+
+test('/user/:id GET should exist', async (t) => {
+  const userId = 'some-id';
+  const { server } = t.context;
+  const res = await server.inject({
+    path: `/user/${userId}`,
+    method: 'GET',
+  });
+  const json = JSON.parse(res.body);
+  t.is(json.userId, userId);
+});
+
+test('/book GET should fail over no query string schema validation', async (t) => {
+  const { server } = t.context;
+  const res = await server.inject({
+    path: `/book`,
+    method: 'GET',
+  });
+  t.is(
+    res.body,
+    `{"statusCode":400,"error":"Bad Request","message":"querystring should have required property 'name'"}`,
+  );
+  t.is(res.statusCode, 400);
+});
+
+test('/book GET should work with query string', async (t) => {
+  const { server } = t.context;
+  const bookName = 'myBook';
+  const res = await server.inject({
+    path: `/book?name=${bookName}`,
+    method: 'GET',
+  });
+  t.is(res.body, `{"name":"${bookName}"}`);
+  t.is(res.statusCode, 200);
+});
+
+test('/group/:id GET should exist', async (t) => {
+  const { server } = t.context;
+  const res = await server.inject({
+    path: `/group/123`,
+    method: 'GET',
+  });
+  t.is(res.statusCode, 200);
+  t.deepEqual(res.json(), { id: '123' });
+});
+
+test('/group/:id/path/topic/:topicId GET should exist', async (t) => {
+  const { server } = t.context;
+  const res = await server.inject({
+    path: `/group/123/path/topic/456`,
+    method: 'GET',
+  });
+  t.is(res.statusCode, 200);
+  t.deepEqual(res.json(), { groupId: '123', topicId: '456' });
+});

--- a/test/regular-server-ts-and-js/test-server/index.ts
+++ b/test/regular-server-ts-and-js/test-server/index.ts
@@ -1,0 +1,12 @@
+import fastify from 'fastify';
+import path from 'path';
+import fastifyNow from '../../../index';
+
+export const initServer = async (port: number) => {
+  const server = fastify();
+  server.register(fastifyNow, {
+    routesFolder: path.join(__dirname, './routes'),
+  });
+  await server.listen(port);
+  return server;
+};

--- a/test/regular-server-ts-and-js/test-server/routes/book.d.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/book.d.ts
@@ -1,0 +1,6 @@
+import { NowRequestHandler } from '../../../../index';
+export declare const GET: NowRequestHandler<{
+  Querystring: {
+    name: string;
+  };
+}>;

--- a/test/regular-server-ts-and-js/test-server/routes/book.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/book.ts
@@ -1,0 +1,17 @@
+import { NowRequestHandler } from '../../../../index';
+
+export const GET: NowRequestHandler<{ Querystring: { name: string } }> = async (req, rep) => {
+  return { name: req.query.name };
+};
+
+GET.opts = {
+  schema: {
+    querystring: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      required: ['name'],
+    },
+  },
+};

--- a/test/regular-server-ts-and-js/test-server/routes/group/:id/index.d.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/group/:id/index.d.ts
@@ -1,0 +1,6 @@
+import { NowRequestHandler } from '../../../../../../index';
+export declare const GET: NowRequestHandler<{
+  Params: {
+    id: string;
+  };
+}>;

--- a/test/regular-server-ts-and-js/test-server/routes/group/:id/index.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/group/:id/index.ts
@@ -1,0 +1,5 @@
+import { NowRequestHandler } from '../../../../../../index';
+
+export const GET: NowRequestHandler<{ Params: { id: string } }> = async (req, rep) => {
+  return { id: req.params.id };
+};

--- a/test/regular-server-ts-and-js/test-server/routes/group/:id/path/topic/:topicId.d.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/group/:id/path/topic/:topicId.d.ts
@@ -1,0 +1,7 @@
+import { NowRequestHandler } from '../../../../../../../../index';
+export declare const GET: NowRequestHandler<{
+  Params: {
+    id: string;
+    topicId: string;
+  };
+}>;

--- a/test/regular-server-ts-and-js/test-server/routes/group/:id/path/topic/:topicId.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/group/:id/path/topic/:topicId.ts
@@ -1,0 +1,8 @@
+import { NowRequestHandler } from '../../../../../../../../index';
+
+export const GET: NowRequestHandler<{ Params: { id: string; topicId: string } }> = async (
+  req,
+  rep,
+) => {
+  return { groupId: req.params.id, topicId: req.params.topicId };
+};

--- a/test/regular-server-ts-and-js/test-server/routes/index.d.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/index.d.ts
@@ -1,0 +1,2 @@
+import { NowRequestHandler } from '../../../../index';
+export declare const GET: NowRequestHandler;

--- a/test/regular-server-ts-and-js/test-server/routes/index.test.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/index.test.ts
@@ -1,0 +1,1 @@
+throw new Error('This test file should be ignored');

--- a/test/regular-server-ts-and-js/test-server/routes/index.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/index.ts
@@ -1,0 +1,5 @@
+import { NowRequestHandler } from '../../../../index';
+
+export const GET: NowRequestHandler = async (req, rep) => {
+  return { message: 'hello world' };
+};

--- a/test/regular-server-ts-and-js/test-server/routes/user/[id].d.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/user/[id].d.ts
@@ -1,0 +1,12 @@
+export function GET(
+  req: any,
+  rep: any,
+): Promise<{
+  userId: any;
+}>;
+export function PUT(
+  req: any,
+  res: any,
+): Promise<{
+  message: string;
+}>;

--- a/test/regular-server-ts-and-js/test-server/routes/user/[id].js
+++ b/test/regular-server-ts-and-js/test-server/routes/user/[id].js
@@ -1,0 +1,10 @@
+const GET = async (req, rep) => {
+  return { userId: req.params.id };
+};
+
+const PUT = async (req, res) => {
+  req.log.info(`updating user with id ${req.params.id}`);
+  return { message: 'user updated' };
+};
+
+module.exports = { GET, PUT };

--- a/test/regular-server-ts-and-js/test-server/routes/user/index.d.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/user/index.d.ts
@@ -1,0 +1,16 @@
+export function POST(req: any, rep: any): Promise<any>;
+export namespace POST {
+  export namespace opts {
+    export namespace schema {
+      export const body: {
+        type: string;
+        properties: {
+          name: {
+            type: string;
+          };
+        };
+        required: string[];
+      };
+    }
+  }
+}

--- a/test/regular-server-ts-and-js/test-server/routes/user/index.js
+++ b/test/regular-server-ts-and-js/test-server/routes/user/index.js
@@ -1,0 +1,27 @@
+const POST = async (req, rep) => {
+  if (req.body.name === 'Jon Doe') {
+    /**
+     * in async function, you can return undefined if you already sent a response
+     * then it won't try to send a response again with the returned value;
+     */
+    rep.status(400);
+    return { message: 'Name can not be Jon Doe' };
+  }
+  return { ...req.body };
+};
+
+POST.opts = {
+  schema: {
+    body: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+      },
+      required: ['name'],
+    },
+  },
+};
+
+module.exports = { POST };

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "declaration": true,
+    "allowJs": true,
     "outDir": "test-build",
     "baseUrl": "test",
     "strict": true

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -8,9 +8,11 @@
     "noImplicitAny": false,
     "moduleResolution": "node",
     "sourceMap": true,
+    "declaration": true,
     "outDir": "test-build",
     "baseUrl": "test",
     "strict": true
   },
+  "include": ["test"],
   "exclude": ["node_modules", "example"]
 }


### PR DESCRIPTION
See #14 

- [x] All tests pass
- [ ] Changes have been documented (TODO)

I would write new tests, but I am not sure how to do so, since there's a `tsc` step when running tests today.

A _workaround_ would be to have a command that runs the existing tests with `ts-node` enabled. This way, all current tests would be ran once in JS, and once in TS.

According to the [AVA documentation for TypeScript](https://github.com/avajs/ava/blob/main/docs/recipes/typescript.md), adding something like that to the `package.json` would work:

```json5
{
  "scripts": {
    "test": "ava test-build/**/*.spec.js", // no change here
    "test:ts": "ava test/**/*.spec.ts" // new script!
  },
  "devDependencies": {
    "ts-node": "^10.2.0", // new dependency
  },
  "ava": {
    "extensions": [ // tell ava to accept both js (test) and ts (test:ts)
      "js", "ts"
    ],
    "require": [ // use ts-node/register in order to transpile TS on the fly
      "ts-node/register"
    ]
  }
}
```

But then we would need to run both `npm run test` and `npm run test:ts`.
