### PR TITLE
Allow setting reply type as a generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ File based routing for [fastify](https://www.fastify.io/) (v3).
 
 For the given folder structure
 
-```bash
+```text
 ├── src
     ├── routes -- routes folder (can be changed)
     |   ├── user -- user resource endpoint folder
@@ -23,7 +23,7 @@ For the given folder structure
 
 will result:
 
-```bash
+```text
 └── / (GET)
     └── user (POST)
         └── /
@@ -75,7 +75,7 @@ Currently supported HTTP methods: `GET, POST, DELETE & PUT`
 
 In `/routes/user/:id/index.ts`:
 
-```javascript
+```typescript
 import { NowRequestHandler } from 'fastify-now';
 
 export const GET: NowRequestHandler<{ Params: { id: string } }> = async (req, rep) => {
@@ -105,13 +105,16 @@ For that, I created a new interface called `NowRequestHandler`.
 
 in `/routes/user/index.ts`:
 
-```javascript
+```typescript
 import { NowRequestHandler } from 'fastify-now';
 
-export const POST: NowRequestHandler<{ Body: { name: string }, Params: { id: string } }> = async (
-  req,
-  rep,
-) => {
+type Post = NowRequestHandler<{
+  Body: { name: string };
+  Params: { id: string };
+  Reply: { message: string } | { userId: string };
+}>;
+
+export const POST: Post = async (req, rep) => {
   if (req.body.name === 'Jon Doe') {
     /**
      * in async function, you can return undefined if you already sent a response

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "fastify": "^3.0.0-rc.4",
+    "fastify": "^3.0.3",
     "fastify-now": "^2.0.0"
   },
   "devDependencies": {

--- a/example/src/routes/user/:id.ts
+++ b/example/src/routes/user/:id.ts
@@ -1,10 +1,17 @@
 import { NowRequestHandler } from 'fastify-now';
 
-export const GET: NowRequestHandler<{ Params: { id: string } }> = async (req, rep) => {
+// Optionally setting the reply type as the handler's return type
+export const GET: NowRequestHandler<{ Params: { id: string } }> = async (
+  req,
+): Promise<{ userId: string }> => {
   return { userId: req.params.id };
 };
 
-export const PUT: NowRequestHandler<{ Params: { id: string } }> = async (req, res) => {
+// Optionally setting the reply type using generics
+export const PUT: NowRequestHandler<{
+  Params: { id: string };
+  Reply: { message: string };
+}> = async (req) => {
   req.log.info(`updating user with id ${req.params.id}`);
   return { message: 'user updated' };
 };

--- a/index.ts
+++ b/index.ts
@@ -6,13 +6,13 @@ import {
   RawServerDefault,
   RawRequestDefaultExpression,
   RawReplyDefaultExpression,
-  RequestGenericInterface,
   ContextConfigDefault,
   RouteShorthandOptions,
   FastifyPluginCallback,
   FastifyRequest,
   FastifyReply,
 } from 'fastify';
+import type { RouteGenericInterface } from 'fastify/types/route';
 import fp from 'fastify-plugin';
 
 enum HTTPMethod {
@@ -103,29 +103,25 @@ const fastifyNow: FastifyPluginCallback<FastifyNowOpts> = (
 
 type NowRouteHandlerMethod<
   RawServer extends RawServerBase = RawServerDefault,
-  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<
-    RawServer
-  >,
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
   RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
-  RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
-  ContextConfig = ContextConfigDefault
+  RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
+  ContextConfig = ContextConfigDefault,
 > = (
   this: FastifyInstance<RawServer, RawRequest, RawReply>,
-  request: FastifyRequest<RequestGeneric, RawServer, RawRequest>,
-  reply: FastifyReply<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>,
+  request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
+  reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   server: FastifyInstance<RawServer, RawRequest, RawReply>,
-) => void | Promise<any>;
+) => RouteGeneric['Reply'] | Promise<RouteGeneric['Reply']>;
 
 export interface NowRequestHandler<
-  RequestGeneric extends RequestGenericInterface = RequestGenericInterface,
+  RouteGeneric extends RouteGenericInterface = RouteGenericInterface,
   ContextConfig = ContextConfigDefault,
   RawServer extends RawServerBase = RawServerDefault,
-  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<
-    RawServer
-  >,
-  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>
-> extends NowRouteHandlerMethod<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig> {
-  opts?: RouteShorthandOptions<RawServer, RawRequest, RawReply, RequestGeneric, ContextConfig>;
+  RawRequest extends RawRequestDefaultExpression<RawServer> = RawRequestDefaultExpression<RawServer>,
+  RawReply extends RawReplyDefaultExpression<RawServer> = RawReplyDefaultExpression<RawServer>,
+> extends NowRouteHandlerMethod<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig> {
+  opts?: RouteShorthandOptions<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>;
 }
 
 export default fp<FastifyNowOpts>(fastifyNow);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": ">=12.x.x"
   },
   "dependencies": {
-    "fastify": "^3.0.0",
+    "fastify": "^3.0.3",
     "fastify-plugin": "^2.0.0"
   },
   "devDependencies": {

--- a/test/regular-server-ts-and-js/test-server/routes/group/:id/index.d.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/group/:id/index.d.ts
@@ -3,4 +3,7 @@ export declare const GET: NowRequestHandler<{
   Params: {
     id: string;
   };
+  Reply: {
+    id: string;
+  };
 }>;

--- a/test/regular-server-ts-and-js/test-server/routes/group/:id/index.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/group/:id/index.ts
@@ -1,5 +1,10 @@
 import { NowRequestHandler } from '../../../../../../index';
 
-export const GET: NowRequestHandler<{ Params: { id: string } }> = async (req, rep) => {
+type Get = NowRequestHandler<{
+  Params: { id: string };
+  Reply: { id: string };
+}>;
+
+export const GET: Get = async (req, rep) => {
   return { id: req.params.id };
 };

--- a/test/regular-server-ts-and-js/test-server/routes/group/:id/path/topic/:topicId.d.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/group/:id/path/topic/:topicId.d.ts
@@ -4,4 +4,8 @@ export declare const GET: NowRequestHandler<{
     id: string;
     topicId: string;
   };
+  Reply: {
+    groupId: string;
+    topicId: string;
+  };
 }>;

--- a/test/regular-server-ts-and-js/test-server/routes/group/:id/path/topic/:topicId.ts
+++ b/test/regular-server-ts-and-js/test-server/routes/group/:id/path/topic/:topicId.ts
@@ -1,8 +1,10 @@
 import { NowRequestHandler } from '../../../../../../../../index';
 
-export const GET: NowRequestHandler<{ Params: { id: string; topicId: string } }> = async (
-  req,
-  rep,
-) => {
+type Get = NowRequestHandler<{
+  Params: { id: string; topicId: string };
+  Reply: { groupId: string; topicId: string };
+}>;
+
+export const GET: Get = async (req, rep) => {
   return { groupId: req.params.id, topicId: req.params.topicId };
 };


### PR DESCRIPTION
See #16 

I updated the docs and some of the tests to demonstrate usage.

This change does not break existing types.

In the same commit, I bumped up fastify's minimal supported version:

- `FastifyPluginCallback` exists only since [fastify's 3.0.1 release](https://github.com/fastify/fastify/releases/tag/v3.0.1) (PR https://github.com/fastify/fastify/pull/2350), so the `"^3.0.0"` dependency was incorrect
- This PR also uses `RouteGenericInterface`, that exists only since [fastify's 3.0.3 release](https://github.com/fastify/fastify/releases/tag/v3.0.3) (PR https://github.com/fastify/fastify/pull/2389).
