### PR TITLE
Allow void return type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -114,7 +114,7 @@ type NowRouteHandlerMethod<
   request: FastifyRequest<RouteGeneric, RawServer, RawRequest>,
   reply: FastifyReply<RawServer, RawRequest, RawReply, RouteGeneric, ContextConfig>,
   server: FastifyInstance<RawServer, RawRequest, RawReply>,
-) => RouteGeneric['Reply'] | Promise<RouteGeneric['Reply']>;
+) => void | RouteGeneric['Reply'] | Promise<RouteGeneric['Reply'] | void>;
 
 export interface NowRequestHandler<
   RouteGeneric extends RouteGenericInterface = RouteGenericInterface,

--- a/test/regular-server/index.spec.ts
+++ b/test/regular-server/index.spec.ts
@@ -117,6 +117,26 @@ test('/book GET should work with query string', async (t) => {
   t.is(res.statusCode, 200);
 });
 
+test('/shelf GET should work', async (t) => {
+  const { server } = t.context;
+  const res = await server.inject({
+    path: `/shelf?name=foo`,
+    method: 'GET',
+  });
+  t.is(res.statusCode, 200);
+  t.deepEqual(res.json(), { name: 'foo' });
+});
+
+test('/shelf GET should fail with invalid name', async (t) => {
+  const { server } = t.context;
+  const res = await server.inject({
+    path: `/shelf?name=test`,
+    method: 'GET',
+  });
+  t.is(res.statusCode, 400);
+  t.deepEqual(res.json(), { message: 'Invalid name' });
+});
+
 test('/group/:id GET should exist', async (t) => {
   const { server } = t.context;
   const res = await server.inject({

--- a/test/regular-server/test-server/routes/shelf.ts
+++ b/test/regular-server/test-server/routes/shelf.ts
@@ -1,0 +1,34 @@
+import { NowRequestHandler } from '../../../../index';
+
+export const GET: NowRequestHandler<{
+  Querystring: { name: string };
+  Reply: { name: string } | { message: string };
+}> = async (req, rep) => {
+  if (req.query.name === 'test') {
+    rep.status(400).send({
+      message: 'Invalid name',
+    });
+    return;
+  }
+  rep.send({ name: req.query.name });
+};
+
+GET.opts = {
+  schema: {
+    querystring: {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      required: ['name'],
+    },
+    response: {
+      '200': {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
Fastify can reply instead of returning a value.
https://github.com/fastify/fastify/blob/aec2ac770036a34ce5a426037ef02070f07ca8ea/types/route.d.ts#L64

But #18 seems to have broken by mistake. 