### PR TITLE
chore(deps): move `fastify` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "node": ">=12.x.x"
   },
   "dependencies": {
-    "fastify": "^4.5.2",
     "fastify-plugin": "^3.0.1"
   },
   "devDependencies": {
@@ -60,6 +59,7 @@
     "eslint": "^8.17.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",
+    "fastify": "^4.5.3",
     "husky": "^4.2.5",
     "prettier": "^2.0.5",
     "ts-node": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "node": ">=12.x.x"
   },
   "dependencies": {
-    "fastify": "^4.0.1",
+    "fastify": "^4.5.2",
     "fastify-plugin": "^3.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "node": ">=12.x.x"
   },
   "dependencies": {
-    "fastify-plugin": "^3.0.1"
+    "fastify-plugin": "^4.2.1"
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",


### PR DESCRIPTION
With version 4.5.2 of fastify, the types were slightly different leading to a mismatch, therefore I moved fastify to a peer dependency for 4.x