### PR TITLE
fix(typescript): Check for tsconfig for users not using ts-node

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,7 @@ const methods: HTTPMethods[] = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT',
 
 const typeScriptEnabled = Boolean(
   // @ts-expect-error 7053 https://github.com/TypeStrong/ts-node/issues/846#issuecomment-631828160
-  process[Symbol.for('ts-node.register.instance')] || process.env.TS_NODE_DEV,
+  process[Symbol.for('ts-node.register.instance')] || process.env.TS_NODE_DEV || fs.existsSync(path.posix.join(process.cwd(), 'tsconfig.json')),
 );
 
 const extensions = ['.js'];


### PR DESCRIPTION
I propose doing a simple check for a `tsconfig.json` file as a fallback. I and (i assume) others use [TSX](https://github.com/esbuild-kit/tsx) as an alternative to `ts-node`. The library won't load as a result.

Happy to edit it with any feedback, this was just a quick patch I setup for myself.

Cheers, thanks for the library 👍🏻 