### PR TITLE
Add ignoring of vitest benchmark files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ will result:
 
 Path params can also be prefixed with `:` E.g. `:id` instead of `[id]`
 
-The plugin will ignore any `.test/spec.js` files when loading routes
+The plugin will ignore any `.{test|spec|bench}.js` files when loading routes
 
 ## Install
 

--- a/index.ts
+++ b/index.ts
@@ -29,7 +29,7 @@ if (typeScriptEnabled) {
 }
 
 const isRoute = (ext: string) => extensions.includes(ext);
-const isTest = (name: string) => name.endsWith('.test') || name.endsWith('.spec');
+const isTest = (name: string) => name.endsWith('.test') || name.endsWith('.spec') || name.endsWith('.bench');
 const isDeclaration = (name: string, ext: string) => ext === '.ts' && name.endsWith('.d');
 
 function addRequestHandler(

--- a/index.ts
+++ b/index.ts
@@ -29,7 +29,8 @@ if (typeScriptEnabled) {
 }
 
 const isRoute = (ext: string) => extensions.includes(ext);
-const isTest = (name: string) => name.endsWith('.test') || name.endsWith('.spec') || name.endsWith('.bench');
+const isTest = (name: string) =>
+  name.endsWith('.test') || name.endsWith('.spec') || name.endsWith('.bench');
 const isDeclaration = (name: string, ext: string) => ext === '.ts' && name.endsWith('.d');
 
 function addRequestHandler(

--- a/test/regular-server/test-server/routes/index.bench.ts
+++ b/test/regular-server/test-server/routes/index.bench.ts
@@ -1,0 +1,1 @@
+throw new Error('This bench file should be ignored');


### PR DESCRIPTION
Currently, fastify-now will ignore `.test.js` and `.spec.js` files. This change adds ignoring of vitest benchmark `.bench.js` files, solving #33.

These changes are submitted per the terms of the MIT License

